### PR TITLE
Переключение версии SDK на 21.1000 в ветке rc-21.1000

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
       "wasaby-app": "git+https://platform-git.sbis.ru/saby/wasaby-app.git#rc-21.1000",
       "sbis3.engine": "git+https://git.sbis.ru/sbis/engine.git#rc-21.1000",
       "saby-inferno": "git+https://platform-git.sbis.ru/saby/inferno.git#rc-21.1000",
-      "wasaby-requirejs-loader": "git+https://platform-git.sbis.ru/saby/wasaby-requirejs-loader#rc-20.7000"
+      "wasaby-requirejs-loader": "git+https://platform-git.sbis.ru/saby/wasaby-requirejs-loader#rc-21.1000"
    },
    "saby-units": {
       "moduleType": "amd",


### PR DESCRIPTION
Мерж создан сборкой "http://ci.sbis.ru/job/sdk_cheker/8465/".